### PR TITLE
Skip attesting the PR in the production apply

### DIFF
--- a/.github/workflows/promote_all.yml
+++ b/.github/workflows/promote_all.yml
@@ -248,5 +248,3 @@ jobs:
       kosli_template_file:           flow-templates/kosli-apply.yml
     secrets:
       kosli_api_token:    "${{ secrets.KOSLI_API_TOKEN}}"
-      kosli_github_token: "${{ secrets.GITHUB_TOKEN }}"
-

--- a/.github/workflows/promote_one.yml
+++ b/.github/workflows/promote_one.yml
@@ -264,4 +264,3 @@ jobs:
       kosli_template_file:           flow-templates/kosli-apply.yml
     secrets:
       kosli_api_token:    "${{ secrets.KOSLI_API_TOKEN}}"
-      kosli_github_token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
CyberDojo does not use Pull Requests to deploy to production, and therefore the PR attestation is unnecessary as part of the terraform deploy part of the promotion workflows.